### PR TITLE
[QUARKS-2] Change Issues Tracker to Jira

### DIFF
--- a/site/_includes/header.html
+++ b/site/_includes/header.html
@@ -79,7 +79,7 @@ limitations under the License.
                     <li class="dropdown"><a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Community</a>
                       <ul class="dropdown-menu">
                         <li><a href="docs/community">Get Involved</a></li>
-                        <li><a href="{{ site.sourceurl }}/issues">Issue Tracker</a></li>
+                        <li><a href="https://issues.apache.org/jira/browse/QUARKS">Issue Tracker</a></li>
                         <li><a href="{{ site.sourceurl }}/">Source Code</a></li>
                         <li><a href="docs/committers">Committers</a></li>
                       </ul>


### PR DESCRIPTION
Just piggybacking this small change on QUARKS-2.
Changes the Issue Tracker to Jira
Please commit and regenerated web site.
