### PR TITLE
[QUARKS-45] Change documentation banner links to point to correct locations for Apache

### DIFF
--- a/site/_config.yml
+++ b/site/_config.yml
@@ -125,4 +125,4 @@ host:    127.0.0.1
 #Base URLs
 docsurl: http://quarks-edge.github.io/quarks.documentation/
 sourceurl: https://github.com/apache/incubator-quarks
-projurl: http://quarks-edge.github.io/quarks
+projurl: http://quarks.incubator.apache.org/

--- a/site/_config.yml
+++ b/site/_config.yml
@@ -125,4 +125,4 @@ host:    127.0.0.1
 #Base URLs
 docsurl: http://quarks-edge.github.io/quarks.documentation/
 sourceurl: https://github.com/apache/incubator-quarks
-projurl: http://quarks.incubator.apache.org/
+projurl: http://quarks-edge.github.io/quarks

--- a/site/_data/mydoc/mydoc_topnav.yml
+++ b/site/_data/mydoc/mydoc_topnav.yml
@@ -12,7 +12,7 @@ topnav:
 #      output: web
 
     - title: Github Repos
-      external_url: https://github.com/quarks-edge
+      external_url: https://github.com/apache/incubator-quarks
       audience: writers, designers
       platform: all
       product: all
@@ -38,7 +38,7 @@ topnav_dropdowns:
       output: web
       items:
         - title: Download
-          external_url: https://github.com/quarks-edge/quarks/releases/latest
+          external_url: https://github.com/apache/incubator-quarks/releases
           audience: writers, designers
           platform: all
           product: all

--- a/site/_data/mydoc/mydoc_topnav.yml
+++ b/site/_data/mydoc/mydoc_topnav.yml
@@ -1,8 +1,5 @@
 ## Topnav single links
 ## if you want to list an external url, use external_url instead of url. the theme will apply a different link base.
-topnav:
-- title: Topnav
-  subcategories:
 #    - title: Sample
 #      url: /mydoc/sample.html
 #      audience: writers, designers
@@ -11,13 +8,36 @@ topnav:
 #      version: all
 #      output: web
 
+
+githubrepos_dropdowns:
+- title: Github Repos dropdowns
+  subcategories:
     - title: Github Repos
-      external_url: https://github.com/apache/incubator-quarks
       audience: writers, designers
       platform: all
       product: all
       version: all
       output: web
+      items:
+        - title: Source code
+          external_url: https://github.com/apache/incubator-quarks
+          audience: writers, designers
+          platform: all
+          product: all
+          version: all
+          output: web
+
+        - title: Website/Documentation
+          external_url: https://github.com/apache/incubator-quarks-website
+          audience: writers, designers
+          platform: all
+          product: all
+          version: all
+          output: web
+
+topnav:
+- title: Topnav
+  subcategories:
     - title: Javadoc
       external_url: https://quarks-edge.github.io/quarks/docs/javadoc/index.html
       audience: writers, designers

--- a/site/_includes/custom/conditions.html
+++ b/site/_includes/custom/conditions.html
@@ -32,6 +32,7 @@ ____            _
 {% if site.project == "mydoc_designers" %}
 {% assign audience = "designers" %}
 {% assign sidebar = site.data.mydoc.mydoc_sidebar.entries %}
+{% assign githubrepos_dropdowns = site.data.mydoc.mydoc_topnav.githubrepos_dropdowns %}
 {% assign topnav = site.data.mydoc.mydoc_topnav.topnav %}
 {% assign topnav_dropdowns = site.data.mydoc.mydoc_topnav.topnav_dropdowns %}
 {% assign version = "all" %}

--- a/site/_includes/feedback.html
+++ b/site/_includes/feedback.html
@@ -13,4 +13,4 @@ window.location.href = uri;
 }
 </script>
 
-<li><a href="https://github.com/quarks-edge/quarks.documentation/issues/new" target="_blank"><i class="fa fa-envelope-o"></i> Feedback</a></li>
+<li><a href="mailto:dev@quarks.incubator.apache.org" target="_blank"><i class="fa fa-envelope-o"></i> Feedback</a></li>

--- a/site/_includes/header.html
+++ b/site/_includes/header.html
@@ -65,7 +65,7 @@ limitations under the License.
                     <span class="icon-bar"></span>
                     <span class="icon-bar"></span>
                 </button>
-                <a class="navbar-brand page-scroll" href="#home">Home</a>
+                <a class="navbar-brand page-scroll" href="{{ site.projurl}}/">Home</a>
             </div>
             <!-- Collect the nav links, forms, and other content for toggling -->
             <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">

--- a/site/_includes/header.html
+++ b/site/_includes/header.html
@@ -65,7 +65,7 @@ limitations under the License.
                     <span class="icon-bar"></span>
                     <span class="icon-bar"></span>
                 </button>
-                <a class="navbar-brand page-scroll" href="{{ site.projurl }}/#home">Home</a>
+                <a class="navbar-brand page-scroll" href="http://quarks.incubator.apache.org/#home">Home</a>
             </div>
             <!-- Collect the nav links, forms, and other content for toggling -->
             <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">

--- a/site/_includes/header.html
+++ b/site/_includes/header.html
@@ -65,7 +65,7 @@ limitations under the License.
                     <span class="icon-bar"></span>
                     <span class="icon-bar"></span>
                 </button>
-                <a class="navbar-brand page-scroll" href="{{ site.projurl}}/">Home</a>
+                <a class="navbar-brand page-scroll" href="{{ site.projurl }}/#home">Home</a>
             </div>
             <!-- Collect the nav links, forms, and other content for toggling -->
             <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
@@ -97,7 +97,7 @@ limitations under the License.
                       <ul class="dropdown-menu">
                         <li><a href="docs/home">Documentation Home</a></li>
                         <li><a href="docs/quarks-getting-started">Getting Started Guide</a></li>
-                        <li><a href="{{ site.projurl}}/docs/javadoc/index.html">Javadoc</a></li>
+                        <li><a href="{{ site.projurl }}/docs/javadoc/index.html">Javadoc</a></li>
                       </ul>
                     </li>
                     <li class="dropdown">

--- a/site/_includes/topnav.html
+++ b/site/_includes/topnav.html
@@ -17,6 +17,30 @@
                 <!-- entries without drop-downs appear here -->
                 <!-- conditional logic to control which topnav appears for the audience defined in the configuration file.-->
                 {% include custom/conditions.html %}
+                <li class="dropdown">
+                    {% for entry in githubrepos_dropdowns %}
+                    {% for subcategory in entry.subcategories %}
+                    {% if subcategory.audience contains audience and subcategory.product contains product and subcategory.platform contains platform and subcategory.version contains version and subcategory.output contains "web" %}
+                    <a href="#" class="dropdown-toggle" data-toggle="dropdown">{{ subcategory.title }}<b class="caret"></b></a>
+                    <ul class="dropdown-menu">
+                        {% for subitem in subcategory.items %}
+                        {% if subitem.audience contains audience and subitem.product contains product and subitem.platform contains platform and subcategory.version contains version and subitem.output contains "web" %}
+                        {% if subitem.external_url %}
+                        <li><a href="{{subitem.external_url}}" target="_blank">{{subitem.title}}</a></li>
+                        {% elsif page.url contains subitem.url %}
+                        <li class="dropdownActive"><a href="{{subitem.url}}">{{subitem.title}}</a></li>
+                        {% else %}
+                        <li><a href="{{subitem.url | replace: "/",""}}">{{subitem.title}}</a></li>
+                        {% endif %}
+                        {% endif %}
+                        {% endfor %}
+                        {% endif %}
+
+                    </ul>
+                </li>
+                {% endfor %}
+                {% endfor %}
+
 
                 {% for entry in topnav %}
                 {% for subcategory in entry.subcategories %}


### PR DESCRIPTION
I've modify website like belows:
1. In header.html
   `Home`
   Change pointing from #home to {{ site.projurl }}/
   I hope site.projurl will change from http://quarks-edge.github.io/quarks/ to http://quarks.incubator.apache.org/
   But please notify me if this argument is wrong.
2. In mydoc_topnav.yml
   `Github Repos`
   Change pointing from https://github.com/quarks-edge to https://github.com/apache/incubator-quarks
   `Download in Quarks Resources`
   Change pointing from https://github.com/quarks-edge/quarks/releases/latest to https://github.com/apache/incubator-quarks/releases
   But I think It's better make apache-release faster(QUARKS-46) than using this URL
3. In feedback.html
   `Feedback`
   Change pointing from https://github.com/quarks-edge/quarks.documentation/issues/new to mailto:dev@quarks.incubator.apache.org
   Because logo in this TopNavi is mailling picture

Futher discussion
- I couldn't link JAVADOC page because gh-pages branch not exist in incubator-quarks. I will create Jira issue for create branch and init JAVADOC
