### PR TITLE
QUARKS-49 cleanup Get Involved and FAQ documentation pages

### DIFF
--- a/site/_data/project.yml
+++ b/site/_data/project.yml
@@ -47,10 +47,10 @@ commits_list_archive_markmail:
 
 jira: QUARKS
 
-source_repository: git://git.apache.org/incubator-quarks.git
+source_repository: https://git-wip-us.apache.org/repos/asf/incubator-quarks.git
 source_repository_mirror: https://github.com/apache/incubator-quarks
 
-website_repository: git://git.apache.org/incubator-quarks-website.git
+website_repository: https://git-wip-us.apache.org/repos/asf/incubator-quarks-website.git
 website_repository_mirror: https://github.com/apache/incubator-quarks-website
 
 podling: true

--- a/site/docs/community.md
+++ b/site/docs/community.md
@@ -59,7 +59,7 @@ Before submitting an issue, please:
 
 * Verify that the bug does in fact exist.
 * Search the issue tracker to verify there is no existing issue reporting the bug you've found.
-* Consider tracking down the bug yourself in the Wink's source and submitting a patch along with your bug report. This is a great time saver for the Wink developers and helps ensure the bug will be fixed quickly.
+* Consider tracking down the bug yourself in the {{ site.data.project.short_name }} source and submitting apull request  along with your bug report. This is a great time saver for the  {{ site.data.project.short_name }} developers and helps ensure the bug will be fixed quickly.
 
 
 

--- a/site/docs/community.md
+++ b/site/docs/community.md
@@ -34,7 +34,7 @@ You can:
 * Report bugs and submit patches.
 * Contribute code, javadocs, documentation.
 
-Visit the [Contributing](http://www.apache.org/foundation/getinvolved.html) page for more information.
+Visit the [Contributing](http://www.apache.org/foundation/getinvolved.html) page and read [DEVELOPMENT.md] (https://github.com/apache/incubator-quarks/blob/master/DEVELOPMENT.md) at the top of the code tree for more information.
 
 ### Mailing list
 

--- a/site/docs/faq.md
+++ b/site/docs/faq.md
@@ -43,7 +43,7 @@ Quarks is a tool for edge analytics that allows you to be more productive. Quark
 
 ## Where can I download Quarks to try it out?
 
-Quarks is migrating from github quarks-edge to Apache. You can download the source from Apache and build it yourself [here][https://github.com/apache/incubator-quarks].  You can also  find pre-Apache releases of Quarks for download [here](https://github.com/quarks-edge/quarks/releases/latest). These releases are not associated with Apache.
+Quarks is migrating from github quarks-edge to Apache. You can download the source from Apache and build it yourself [here](https://github.com/apache/incubator-quarks).  You can also  find already built pre-Apache releases of Quarks for download [here](https://github.com/quarks-edge/quarks/releases/latest). These releases are not associated with Apache.
 
 ## How do I get started?
 
@@ -55,7 +55,7 @@ Getting started is simple. Once you have downloaded Quarks, everything you need 
 
 ## How can I contribute code?
 
-Just submit a [pull request](https://github.com/apache/incubator-quarks) and wait for a committer to review.  For more information, visit our [committer page](committers).
+Just submit a [pull request](https://github.com/apache/incubator-quarks) and wait for a committer to review.  For more information, visit our [committer page](committers) and read [DEVELOPMENT.md] (https://github.com/apache/incubator-quarks/blob/master/DEVELOPMENT.md) at the top of the code tree.
 
 ## Can I become a committer?
 
@@ -84,4 +84,4 @@ Use [site.data.project.user_list](mailto:{{ site.data.project.user_list }}) to s
 
 ## Why is Quarks Open Source?
 
-With the growth of the Internet of Things there is a need to execute analytics at the edge. Quarks was developed to address requirements for analytics at the edge for IoT use cases that were not addressed by central analytic solutions.  We believe that these capabilities will be useful to many organizations and that the diverse nature of edge devices and use cases is best addressed by an open community.  Our goal is to develop a vibrant community of developers and users to expand the capabilities and real-world use of Quarks by companies and individuals to enable edge analytics and further innovation for the IoT space.
+With the growth of the Internet of Things there is a need to execute analytics at the edge. Quarks was developed to address requirements for analytics at the edge for IoT use cases that were not addressed by central analytic solutions.  These capabilities will be useful to many organizations and that the diverse nature of edge devices and use cases is best addressed by an open community.  Our goal is to develop a vibrant community of developers and users to expand the capabilities and real-world use of Quarks by companies and individuals to enable edge analytics and further innovation for the IoT space.

--- a/site/docs/faq.md
+++ b/site/docs/faq.md
@@ -43,7 +43,7 @@ Quarks is a tool for edge analytics that allows you to be more productive. Quark
 
 ## Where can I download Quarks to try it out?
 
-You will find a release of Quarks for download [here](https://github.com/quarks-edge/quarks/releases/latest).
+Quarks is migrating from github quarks-edge to Apache. You can download the source from Apache and build it yourself [here][https://github.com/apache/incubator-quarks].  You can also  find pre-Apache releases of Quarks for download [here](https://github.com/quarks-edge/quarks/releases/latest). These releases are not associated with Apache.
 
 ## How do I get started?
 
@@ -51,11 +51,11 @@ Getting started is simple. Once you have downloaded Quarks, everything you need 
 
 ## How can I get involved?
 
- We would love to have your help! Visit [Get Involved](getinvolved) to learn more about how to get involved.
+ We would love to have your help! Visit [Get Involved](community) to learn more about how to get involved.
 
 ## How can I contribute code?
 
-Just submit a [pull request](https://github.com/quarks-edge/quarks/pulls) and wait for a committer to review.  For more information, visit our [committer page](committers).
+Just submit a [pull request](https://github.com/apache/incubator-quarks) and wait for a committer to review.  For more information, visit our [committer page](committers).
 
 ## Can I become a committer?
 
@@ -63,7 +63,7 @@ Read about Quarks committers and how to become a committer [here](committers).
 
 ## Where can I get the code?
 
-The source code is available [here](https://github.com/quarks-edge/quarks/).
+The source code is available [here](https://github.com/apache/incubator-quarks).
 
 ## Can I take a copy of the code and fork it for my own use?
 
@@ -71,16 +71,17 @@ Yes. Quarks is available under the Apache 2.0 license which allows you to fork t
 
 ## How do I suggest new features?
 
-Click [Issues](https://github.com/quarks-edge/quarks/issues) to submit requests for new features. You may browse or query the Issues database to see what other members of the Quarks community have already requested.
+Click [Issues](https://issues.apache.org/jira/browse/QUARKS)
+ to submit requests for new features. You may browse or query the Issues database to see what other members of the Quarks community have already requested.
 
 ## How do I submit bug reports?
 
-Click [Issues](https://github.com/quarks-edge/quarks/issues) to submit a bug report.
+Click [Issues](https://issues.apache.org/jira/browse/QUARKS) to submit a bug report.
 
 ## How do I ask questions about Quarks?
 
-Use [Issues](https://github.com/quarks-edge/quarks/issues) to submit questions to the Quarks community.
+Use [site.data.project.user_list](mailto:{{ site.data.project.user_list }}) to submit questions to the Quarks community.
 
-## Why did IBM open source Quarks?
+## Why is Quarks Open Source?
 
 With the growth of the Internet of Things there is a need to execute analytics at the edge. Quarks was developed to address requirements for analytics at the edge for IoT use cases that were not addressed by central analytic solutions.  We believe that these capabilities will be useful to many organizations and that the diverse nature of edge devices and use cases is best addressed by an open community.  Our goal is to develop a vibrant community of developers and users to expand the capabilities and real-world use of Quarks by companies and individuals to enable edge analytics and further innovation for the IoT space.


### PR DESCRIPTION
Changed Get Involved to fix some links and put in Quarks instead of Wink.
Changed FAQ to make things more current and fix some links.
