### PR TITLE
Moved Getting Started Guide link

### DIFF
--- a/site/_includes/header.html
+++ b/site/_includes/header.html
@@ -86,6 +86,7 @@ limitations under the License.
                     </li>
                     <li class="dropdown"><a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Getting Started</a>
                       <ul class="dropdown-menu">
+                        <li><a href="docs/quarks-getting-started">Getting Started Guide</a></li>
                         <li><a href="{{ site.sourceurl }}">Download Source</a></li>
                         <li><a href="docs/samples">Sample Programs</a></li>
                         <li><a href="docs/faq">FAQ</a></li>
@@ -96,7 +97,6 @@ limitations under the License.
                       <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Documentation</a>
                       <ul class="dropdown-menu">
                         <li><a href="docs/home">Documentation Home</a></li>
-                        <li><a href="docs/quarks-getting-started">Getting Started Guide</a></li>
                         <li><a href="{{ site.projurl }}/docs/javadoc/index.html">Javadoc</a></li>
                       </ul>
                     </li>

--- a/site/_includes/incubation.html
+++ b/site/_includes/incubation.html
@@ -26,6 +26,7 @@ limitations under the License.
                     <h2 class="section-heading">Apache Quarks (incubating)</h2>
                     <div class="lead">Apache Quarks is a programming model and micro-kernel style runtime that can be embedded in gateways and small footprint edge devices enabling local, real-time, analytics on the continuous streams of data coming from equipment, vehicles, systems, appliances, devices and sensors of all kinds (for example, Raspberry Pis or smart phones). Working in conjunction with centralized analytic systems, Apache Quarks provides efficient and timely analytics across the whole IoT ecosystem: from the center to the edge.</div>
                 </div>
+            </div>
         </div>
     </div>
 </section>


### PR DESCRIPTION
Getting Started guide link wasn't under the Getting Started dropdown at
the top.

Didn't want to create a whole new branch and issue for this, so using QUARKS-109. 
