### PR TITLE
Update FAQ to use Apache Quarks QUARKS-144

### DIFF
--- a/site/docs/faq.md
+++ b/site/docs/faq.md
@@ -1,7 +1,7 @@
 ---
 title: FAQ  
 ---
-## What is Quarks?
+## What is Apache Quarks?
 
 Quarks provides APIs and a lightweight runtime to analyze streaming data at the edge.
 
@@ -9,7 +9,7 @@ Quarks provides APIs and a lightweight runtime to analyze streaming data at the 
 
 The edge includes devices, gateways, equipment, vehicles, systems, appliances and sensors of all kinds as part of the Internet of Things.
 
-## How is Quarks used?
+## How is Apache Quarks used?
 
 Quarks can be used at the edge of the Internet of Things, for example, to analyze data on devices, engines, connected cars, etc.  Quarks could be on the device itself, or a gateway device collecting data from local devices.  You can write an edge application on Quarks and connect it to a Cloud service, such as the IBM Watson IoT Platform. It can also be used for enterprise data collection and analysis; for example log collectors, application data, and data center analytics.
 
@@ -17,31 +17,31 @@ Quarks can be used at the edge of the Internet of Things, for example, to analyz
 
 Applications are developed using a functional flow API to define operations on data streams that are executed as a graph of "oplets" in a lightweight embeddable runtime.  The SDK provides capabilities like windowing, aggregation and connectors with an extensible model for the community to expand its capabilities.
 
-## What APIs does Quarks support?
+## What APIs does Apache Quarks support?
 
 Currently, Quarks supports APIs for Java and Android. Support for additional languages, such as Python, is likely as more developers get involved.  Please consider joining the Quarks open source development community to accelerate the contributions of additional APIs.
 
-## What type of analytics can be done with Quarks?
+## What type of analytics can be done with Apache Quarks?
 
 Quarks provides windowing, aggregation and simple filtering. It uses Apache Common Math to provide simple analytics aimed at device sensors.  Quarks is also extensible, so you can call existing libraries from within your Quarks application.  In the future, Quarks will include more analytics, either exposing more functionality from Apache Common Math, other libraries or hand-coded analytics.
 
-## What connectors does Quarks support?
+## What connectors does Apache Quarks support?
 
 Quarks supports connectors for MQTT, HTTP, JDBC, File, Apache Kafka and IBM Watson IoT Platform.  Quarks is extensible; you can add the connector of your choice.
 
-## What centralized streaming analytic systems does Quarks support?
+## What centralized streaming analytic systems does Apache Quarks support?
 
 Quarks supports open source technology (such as Apache Spark, Apache Storm, Flink and samza), IBM Streams (on-premises or IBM Streaming Analytics on Bluemix), or any custom application of your choice.
 
-## Why do I need Quarks on the edge, rather than my streaming analytic system?
+## Why do I need Apache Quarks on the edge, rather than my streaming analytic system?
 
 Quarks is designed for the edge, rather than a more centralized system.  It has a small footprint, suitable for running on devices.  Quarks provides simple analytics, allowing a device to analyze data locally and to only send to the centralized system if there is a need, reducing communication costs.
 
-## Why do I need Quarks, rather than coding the complete application myself?
+## Why do I need Apache Quarks, rather than coding the complete application myself?
 
 Quarks is a tool for edge analytics that allows you to be more productive. Quarks provides a consistent data model (streams and windows) and provides useful functionality, such as aggregations, joins, etc. Using Quarks lets you to take advantage of this functionality, allowing you to focus on your application needs.
 
-## Where can I download Quarks to try it out?
+## Where can I download Apache Quarks to try it out?
 
 Quarks is migrating from github quarks-edge to Apache. You can download the source from Apache and build it yourself [here](https://github.com/apache/incubator-quarks).  You can also  find already built pre-Apache releases of Quarks for download [here](https://github.com/quarks-edge/quarks/releases/latest). These releases are not associated with Apache.
 
@@ -78,10 +78,10 @@ Click [Issues](https://issues.apache.org/jira/browse/QUARKS)
 
 Click [Issues](https://issues.apache.org/jira/browse/QUARKS) to submit a bug report.
 
-## How do I ask questions about Quarks?
+## How do I ask questions about Apache Quarks?
 
 Use [site.data.project.user_list](mailto:{{ site.data.project.user_list }}) to submit questions to the Quarks community.
 
-## Why is Quarks open source?
+## Why is Apache Quarks open source?
 
 With the growth of the Internet of Things there is a need to execute analytics at the edge. Quarks was developed to address requirements for analytics at the edge for IoT use cases that were not addressed by central analytic solutions.  These capabilities will be useful to many organizations and that the diverse nature of edge devices and use cases is best addressed by an open community.  Our goal is to develop a vibrant community of developers and users to expand the capabilities and real-world use of Quarks by companies and individuals to enable edge analytics and further innovation for the IoT space.


### PR DESCRIPTION
Update the FAQ to use Apache Quarks, rather than just Quarks in the questions QUARKS-144.
