### PR TITLE
[QUARKS-162] create DOAP file for Quarks

### DIFF
--- a/site/doap_Quarks.rdf
+++ b/site/doap_Quarks.rdf
@@ -33,6 +33,9 @@
     <mailing-list rdf:resource="http://quarks.incubator.apache.org/docs/community#mailing-list" />
     <programming-language>Java</programming-language>
     <programming-language>JavaScript</programming-language>
+    <category rdf:resource="http://projects.apache.org/category/big-data" />
+    <category rdf:resource="http://projects.apache.org/category/library" />
+    <category rdf:resource="http://projects.apache.org/category/mobile" />
     <category rdf:resource="http://projects.apache.org/category/network-client" />
     <repository>
       <GitRepository>

--- a/site/doap_Quarks.rdf
+++ b/site/doap_Quarks.rdf
@@ -1,0 +1,50 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl"?>
+<rdf:RDF xml:lang="en"
+         xmlns="http://usefulinc.com/ns/doap#"
+         xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+         xmlns:asfext="http://projects.apache.org/ns/asfext#"
+         xmlns:foaf="http://xmlns.com/foaf/0.1/">
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+  <Project rdf:about="http://quarks.incubator.apache.org/">
+    <created>2016-04-30</created>
+    <license rdf:resource="http://spdx.org/licenses/Apache-2.0" />
+    <name>Apache Quarks</name>
+    <homepage rdf:resource="http://quarks.incubator.apache.org/" />
+    <asfext:pmc rdf:resource="http://incubator.apache.org" />
+    <shortdesc>Quarks is a stream processing programming model and lightweight runtime to execute analytics at devices on the edge or at the gateway.</shortdesc>
+    <description>Apache Quarks is a programming model and micro-kernel style runtime that can be embedded in gateways and small footprint edge devices enabling local, real-time, analytics on the continuous streams of data coming from equipment, vehicles, systems, appliances, devices and sensors of all kinds (for example, Raspberry Pis or smart phones). Working in conjunction with centralized analytic systems, Apache Quarks provides efficient and timely analytics across the whole IoT ecosystem: from the center to the edge.</description>
+    <bug-database rdf:resource="https://issues.apache.org/jira/browse/QUARKS" />
+    <mailing-list rdf:resource="http://quarks.incubator.apache.org/docs/community#mailing-list" />
+    <programming-language>Java</programming-language>
+    <programming-language>JavaScript</programming-language>
+    <category rdf:resource="http://projects.apache.org/category/network-client" />
+    <repository>
+      <GitRepository>
+        <location rdf:resource="https://git-wip-us.apache.org/repos/asf/incubator-quarks.git"/>
+        <browse rdf:resource="https://git-wip-us.apache.org/repos/asf?p=incubator-quarks.git"/>
+      </GitRepository>
+    </repository>
+    <maintainer>
+      <foaf:Person>
+        <foaf:name>Cazen Lee</foaf:name>
+          <foaf:mbox rdf:resource="mailto:cazen@apache.org"/>
+      </foaf:Person>
+    </maintainer>
+  </Project>
+</rdf:RDF>


### PR DESCRIPTION
- Validate completed by W3C RDF Validator service (http://www.w3.org/RDF/Validator/)
- I couldn’t determine proper Quarks’ categories. I have selected a network-client but please tell me if you have another idea. And listing all categories page(https://projects.apache.org/categories.html) seems that broken.
- I don't have commit privilege yet. I will append after get a permission

This `<location>http://quarks.incubator.apache.org/doap_Quarks.rdf</location>`
to `https://svn.apache.org/repos/asf/comdev/projects.apache.org/data/projects.xml`
- I will maintain this DOAP file.
