### PR TITLE
[QUARKS-164] Navigation menu works the wrong way

### DIFF
--- a/site/_includes/header.html
+++ b/site/_includes/header.html
@@ -25,7 +25,7 @@ limitations under the License.
 		<div class="container">
 
 			<div class="row">
-				<div class="col-lg-4  vcenter">
+				<div class="col-lg-4 vcenter">
 					<div class="intro-message">
 						<img class="logo-img" src="img/apache_logo.png" alt="">
                         <!-- <h1>{{ page.title }}</h1> -->
@@ -54,10 +54,10 @@ limitations under the License.
 
 <!-- Navigation -->
 <div id="nav-bar">
-    <nav  id="nav-container" class="navbar navbar-inverse " role="navigation">
+    <nav id="nav-container" class="navbar navbar-inverse " role="navigation">
         <div class="container">
             <!-- Brand and toggle get grouped for better mobile display -->
-           
+
             <div class="navbar-header page-scroll">
                 <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#bs-example-navbar-collapse-1">
                     <span class="sr-only">Toggle navigation</span>

--- a/site/js/landing-page.js
+++ b/site/js/landing-page.js
@@ -14,11 +14,6 @@ $('body').scrollspy({
     target: '.navbar-fixed-top'
 })
 
-// Closes the Responsive Menu on Menu Item Click
-$('.navbar-collapse ul li a').click(function() {
-    $('.navbar-toggle:visible').click();
-});
-
 $('div.modal').on('show.bs.modal', function() {
 	var modal = this;
 	var hash = modal.id;


### PR DESCRIPTION
I think that "Closes the Responsive Menu on Menu Item Click" function is unnecessary.
Mobile device that receives a "touch input" doesn't have "mouse over". So we should click on 1depth menu if wanna to see a 2depth menu. But in case of that, nav-bar will be collapsed. 
landing-page.js seems that used index.html only.
