### PR TITLE
[EDGENT-233] Fix broken Javadoc and GitHub links

### DIFF
--- a/site/_config.yml
+++ b/site/_config.yml
@@ -125,4 +125,4 @@ host:    127.0.0.1
 #Base URLs
 sourceurl: https://github.com/apache/incubator-edgent
 projurl: http://edgent.incubator.apache.org
-docsurl: http://edgent.incubator.apache.org/javadoc
+docsurl: http://edgent.incubator.apache.org/javadoc/latest

--- a/site/docs/console.md
+++ b/site/docs/console.md
@@ -50,7 +50,7 @@ try {
 dp.submit(topology);
 ```
 
-The other way to embed the console in your application is shown in the `HttpServerSample.java` example (on [GitHub]({{ site.data.project.source_repository_mirror }}/blob/master/samples/console/src/main/java/{{ site.data.project.unix_name }}/samples/console/HttpServerSample.java)). It gets the `HttpServer` instance, starts it, and prints out the console URL. Note that it does not submit a job, so when the console is displayed in the browser, there are no running jobs and therefore no topology graph. The example is meant to show how to get the `HttpServer` instance, start the console web app and get the URL of the console.
+The other way to embed the console in your application is shown in the `HttpServerSample.java` example (on [GitHub]({{ site.data.project.source_repository_mirror }}/blob/master/samples/console/src/main/java/org/apache/{{ site.data.project.unix_name }}/samples/console/HttpServerSample.java)). It gets the `HttpServer` instance, starts it, and prints out the console URL. Note that it does not submit a job, so when the console is displayed in the browser, there are no running jobs and therefore no topology graph. The example is meant to show how to get the `HttpServer` instance, start the console web app and get the URL of the console.
 
 ## Accessing the console
 
@@ -64,7 +64,7 @@ If you cannot access the console at this URL, ensure there is a `console.war` fi
 
 ## ConsoleWaterDetector sample
 
-To see the features of the console in action and as a way to demonstrate how to monitor a topology in the console, let's look at the `ConsoleWaterDetector` sample (on [GitHub]({{ site.data.project.source_repository_mirror }}/blob/master/samples/console/src/main/java/{{ site.data.project.unix_name }}/samples/console/ConsoleWaterDetector.java)).
+To see the features of the console in action and as a way to demonstrate how to monitor a topology in the console, let's look at the `ConsoleWaterDetector` sample (on [GitHub]({{ site.data.project.source_repository_mirror }}/blob/master/samples/console/src/main/java/org/apache/{{ site.data.project.unix_name }}/samples/console/ConsoleWaterDetector.java)).
 
 Prior to running any console applications, the `console.war` file must be built as mentioned above. If you are building Edgent from a Git repository, go to the top level Edgent directory and run `ant`.
 
@@ -402,7 +402,7 @@ If you scroll the browser window down, you can see a Metrics section. This secti
 
 ## Counters
 
-In the `ConsoleWaterDetector` application we used a `DevelopmentProvider`. Therefore, counters were added to most streams (edges) with the following exceptions (from the [Javadoc]({{ site.docsurl }}/latest/{{ site.data.project.unix_name }}/metrics/Metrics.html#counter-{{ site.data.project.unix_name }}.topology.TStream-) for `edgent.metrics.Metrics`):
+In the `ConsoleWaterDetector` application we used a `DevelopmentProvider`. Therefore, counters were added to most streams (edges) with the following exceptions (from the [Javadoc]({{ site.docsurl }}/org/apache/{{ site.data.project.unix_name }}/metrics/Metrics.html#counter-org.apache.{{ site.data.project.unix_name }}.topology.TStream-) for `edgent.metrics.Metrics`):
 
 *Oplets are only inserted upstream from a FanOut oplet.*
 

--- a/site/docs/edgent-getting-started.md
+++ b/site/docs/edgent-getting-started.md
@@ -109,7 +109,7 @@ To understand how the application processes the stream, let's review each line.
 
 ### Specifying a provider
 
-Your first step when you write an Edgent application is to create a [`DirectProvider`]({{ site.docsurl }}/latest/index.html?edgent/providers/direct/DirectProvider.html):
+Your first step when you write an Edgent application is to create a [`DirectProvider`]({{ site.docsurl }}/index.html?org/apache/{{ site.data.project.unix_name }}/providers/direct/DirectProvider.html):
 
 ```java
 DirectProvider dp = new DirectProvider();
@@ -119,7 +119,7 @@ A `Provider` is an object that contains information on how and where your Edgent
 
 ### Creating a topology
 
-Additionally a Provider is used to create a [`Topology`]({{ site.docsurl }}/latest/index.html?edgent/topology/Topology.html) instance:
+Additionally a Provider is used to create a [`Topology`]({{ site.docsurl }}/index.html?org/apache/{{ site.data.project.unix_name }}/topology/Topology.html) instance:
 
 ```java
 Topology topology = dp.newTopology();

--- a/site/docs/quickstart.md
+++ b/site/docs/quickstart.md
@@ -7,11 +7,11 @@ title: Quickstart IBM Watson IoT Platform sample
 IoT devices running Edgent applications typically connect to back-end analytic systems through a message hub. Message hubs are used to isolate the back-end system from having to handle connections from thousands to millions of devices.
 
 An example of such a message hub designed for the Internet of Things is [IBM Watson IoT Platform](https://internetofthings.ibmcloud.com/). This cloud service runs on IBM's Bluemix cloud platform
-and Edgent provides a [connector]({{ site.docsurl }}/latest/index.html?{{ site.data.project.unix_name }}/connectors/iotf/IotfDevice.html).
+and Edgent provides a [connector]({{ site.docsurl }}/index.html?org/apache/{{ site.data.project.unix_name }}/connectors/iotp/IotpDevice.html).
 
-You can test out the service without any registration by using its Quickstart service and the Edgent sample application: [code]({{ site.data.project.source_repository_mirror }}/blob/master/samples/connectors/src/main/java/{{ site.data.project.unix_name }}/samples/connectors/iotf/IotfQuickstart.java), [Javadoc]({{ site.docsurl }}/latest/index.html?{{ site.data.project.unix_name }}/samples/connectors/iotf/IotfQuickstart.html).
+You can test out the service without any registration by using its Quickstart service and the Edgent sample application: [code]({{ site.data.project.source_repository_mirror }}/blob/master/samples/connectors/src/main/java/org/apache/{{ site.data.project.unix_name }}/samples/connectors/iotp/IotpQuickstart.java), [Javadoc]({{ site.docsurl }}/index.html?org/apache/{{ site.data.project.unix_name }}/samples/connectors/iotp/IotpQuickstart.html).
 
-You can execute the class directly from Eclipse, or using the script: [`edgent/java8/scripts/connectors/iotf/runiotfquickstart.sh`]({{ site.data.project.source_repository_mirror }}/blob/master/scripts/connectors/iotf/runiotfquickstart.sh)
+You can execute the class directly from Eclipse, or using the script: [`edgent/java8/scripts/connectors/iotp/runiotpquickstart.sh`]({{ site.data.project.source_repository_mirror }}/blob/master/scripts/connectors/iotp/runiotpquickstart.sh)
 
 When run it produces output like this, with a URL as the third line.
 
@@ -25,14 +25,14 @@ Here's an example view:
 
 ## Edgent code
 
-The full source is at: [IotfQuickstart.java]({{ site.data.project.source_repository_mirror }}/blob/master/samples/connectors/src/main/java/{{ site.data.project.unix_name }}/samples/connectors/iotf/IotfQuickstart.java).
+The full source is at: [IotpQuickstart.java]({{ site.data.project.source_repository_mirror }}/blob/master/samples/connectors/src/main/java/org/apache/{{ site.data.project.unix_name }}/samples/connectors/iotp/IotpQuickstart.java).
 
 The first step to is to create a `IotDevice` instance that represents the connection to IBM Watson IoT Platform Quickstart service.
 
 ```java
-// Declare a connection to IoTF Quickstart service
+// Declare a connection to IoTP Quickstart service
 String deviceId = "qs" + Long.toHexString(new Random().nextLong());
-IotDevice device = IotfDevice.quickstart(topology, deviceId);
+IotDevice device = IotpDevice.quickstart(topology, deviceId);
 ```
 
 Now any stream can send device events to the Quickstart service by simply calling its `events()` method. Here we map a stream of random numbers into JSON as the payload for a device event is typically JSON.

--- a/site/docs/samples.md
+++ b/site/docs/samples.md
@@ -40,4 +40,4 @@ In addition to the sample application in the [Getting started guide](edgent-gett
   - Samples that demonstrate how to use IBM Watson IoT Platform as the IoT scale message hub between Edgent and back-end analytic systems:
       * [Sample using the no-registration Quickstart service](quickstart)
 
-Additional samples are documented in the [Edgent Overview]({{ site.docsurl }}/latest/overview-summary.html#overview.description) section of the Javadoc.
+Additional samples are documented in the [Edgent Overview]({{ site.docsurl }}/overview-summary.html#overview.description) section of the Javadoc.

--- a/site/recipes/recipe_adaptable_deadtime_filter.md
+++ b/site/recipes/recipe_adaptable_deadtime_filter.md
@@ -12,7 +12,7 @@ Note this is a different case than simply changing the polling frequency for the
 
 This case needs a *deadtime filter* and Edgent provides one for your use! In contrast to a *deadband filter*, which skips tuples based on a deadband value range, a deadtime filter skips tuples based on a *deadtime period* following a tuple that is allowed to pass through. For example, if the deadtime period is 30 minutes, after allowing a tuple to pass, the filter skips any tuples received for the next 30 minutes. The next tuple received after that is allowed to pass through, and a new deadtime period is begun.
 
-See `edgent.analytics.sensors.Filters.deadtime()` (on [GitHub]({{ site.data.project.source_repository_mirror }}/blob/master/analytics/sensors/src/main/java/{{ site.data.project.unix_name }}/analytics/sensors/Filters.java)) and `edgent.analytics.sensors.Deadtime` (on [GitHub]({{ site.data.project.source_repository_mirror }}/blob/master/analytics/sensors/src/main/java/{{ site.data.project.unix_name }}/analytics/sensors/Deadtime.java)).
+See `edgent.analytics.sensors.Filters.deadtime()` (on [GitHub]({{ site.data.project.source_repository_mirror }}/blob/master/analytics/sensors/src/main/java/org/apache/{{ site.data.project.unix_name }}/analytics/sensors/Filters.java)) and `edgent.analytics.sensors.Deadtime` (on [GitHub]({{ site.data.project.source_repository_mirror }}/blob/master/analytics/sensors/src/main/java/org/apache/{{ site.data.project.unix_name }}/analytics/sensors/Deadtime.java)).
 
 This recipe demonstrates how to use an adaptable deadtime filter.
 

--- a/site/recipes/recipe_adaptable_filter_range.md
+++ b/site/recipes/recipe_adaptable_filter_range.md
@@ -2,7 +2,7 @@
 title: Changing a filter's range
 ---
 
-The [Detecting a sensor value out of range](recipe_value_out_of_range.html) recipe introduced the basics of filtering as well as the use of a [Range]({{ site.docsurl }}/latest/{{ site.data.project.unix_name }}/analytics/sensors/Range.html).
+The [Detecting a sensor value out of range](recipe_value_out_of_range.html) recipe introduced the basics of filtering as well as the use of a [Range]({{ site.docsurl }}/index.html?org/apache/{{ site.data.project.unix_name }}/analytics/sensors/Range.html).
 
 Oftentimes, a user wants a filter's behavior to be adaptable rather than static. A filter's range can be made changeable via commands from some external source or just changed as a result of some other local analytics.
 

--- a/site/recipes/recipe_adaptable_polling_source.md
+++ b/site/recipes/recipe_adaptable_polling_source.md
@@ -8,7 +8,7 @@ Oftentimes, a user wants the poll frequency to be adaptable rather than static. 
 
 An Edgent `IotProvider` and `IoTDevice` with its command streams would be a natural way to control the application. In this recipe we will just simulate a "set poll period" command stream.
 
-The `Topology.poll()` [documentation]({{ site.docsurl }}/latest/{{ site.data.project.unix_name }}/topology/Topology.html#poll-{{ site.data.project.unix_name }}.function.Supplier-long-java.util.concurrent.TimeUnit-) describes how the poll period may be changed at runtime.
+The `Topology.poll()` [documentation]({{ site.docsurl }}/org/apache/{{ site.data.project.unix_name }}/topology/Topology.html#poll-org.apache.{{ site.data.project.unix_name }}.function.Supplier-long-java.util.concurrent.TimeUnit-) describes how the poll period may be changed at runtime.
 
 The mechanism is based on a more general Edgent runtime `edgent.execution.services.ControlService` service. The runtime registers "control beans" for entities that are controllable. These controls can be retrieved at runtime via the service.
 

--- a/site/recipes/recipe_combining_streams_processing_results.md
+++ b/site/recipes/recipe_combining_streams_processing_results.md
@@ -99,7 +99,7 @@ TStream<Map<String, Integer>> readings = top
 
 ## Splitting the readings
 
-We are now ready to split the `readings` stream by the blood pressure category. Let's look more closely at the method declaration of `split` below. For more details about `split`, refer to the [Javadoc]({{ site.docsurl }}/latest/{{ site.data.project.unix_name }}/topology/TStream.html#split-int-{{ site.data.project.unix_name }}.function.ToIntFunction-).
+We are now ready to split the `readings` stream by the blood pressure category. Let's look more closely at the method declaration of `split` below. For more details about `split`, refer to the [Javadoc]({{ site.docsurl }}/org/apache/{{ site.data.project.unix_name }}/topology/TStream.html#split-int-org.apache.{{ site.data.project.unix_name }}.function.ToIntFunction-).
 
 ```java
 java.util.List<TStream<T>> split(int n, ToIntFunction<T> splitter)
@@ -208,7 +208,7 @@ TStream<String> hypertensiveAlerts = hypertensive
 
 ## Combining the alert streams
 
-At this point, we have five streams of alerts. Suppose the doctors are interested in seeing a combination of the *Normal* alerts and *Prehypertension* alerts. Or, suppose that they would like to see all of the alerts from all categories together. Here, `union` comes in handy. For more details about `union`, refer to the [Javadoc]({{ site.docsurl }}/latest/{{ site.data.project.unix_name }}/topology/TStream.html#union-{{ site.data.project.unix_name }}.topology.TStream-).
+At this point, we have five streams of alerts. Suppose the doctors are interested in seeing a combination of the *Normal* alerts and *Prehypertension* alerts. Or, suppose that they would like to see all of the alerts from all categories together. Here, `union` comes in handy. For more details about `union`, refer to the [Javadoc]({{ site.docsurl }}/org/apache/{{ site.data.project.unix_name }}/topology/TStream.html#union-org.apache.{{ site.data.project.unix_name }}.topology.TStream-).
 
 There are two ways to define a union. You can either union a `TStream` with another `TStream`, or with a set of streams (`Set<TStream<T>>`). In both cases, a single `TStream` is returned containing the tuples that flow on the input stream(s).
 
@@ -251,7 +251,7 @@ Finally, we can terminate the stream and print out all alerts.
 allAlerts.sink(tuple -> System.out.println(tuple));
 ```
 
-We end our application by submitting the `Topology`. Note that this application is available as a [sample]({{ site.data.project.source_repository_mirror }}/blob/master/samples/topology/src/main/java/{{ site.data.project.unix_name }}/samples/topology/CombiningStreamsProcessingResults.java).
+We end our application by submitting the `Topology`. Note that this application is available as a [sample]({{ site.data.project.source_repository_mirror }}/blob/master/samples/topology/src/main/java/org/apache/{{ site.data.project.unix_name }}/samples/topology/CombiningStreamsProcessingResults.java).
 
 ## Observing the output
 

--- a/site/recipes/recipe_different_processing_against_stream.md
+++ b/site/recipes/recipe_different_processing_against_stream.md
@@ -56,7 +56,7 @@ public class ApplyDifferentProcessingAgainstStream {
 
 ## Generating gas mileage sensor readings
 
-The next step is to simulate a stream of gas mileage readings using [`SimpleSimulatedSensor`]({{ site.data.project.source_repository_mirror }}/blob/master/samples/utils/src/main/java/{{ site.data.project.unix_name }}/samples/utils/sensor/SimpleSimulatedSensor.java). We set the initial gas mileage and delta factor in the first two arguments. The last argument ensures that the sensor reading falls in an acceptable range (between 7.0 mpg and 14.0 mpg). In our `main()`, we use the `poll()` method to generate a flow of tuples (readings), where each tuple arrives every second.
+The next step is to simulate a stream of gas mileage readings using [`SimpleSimulatedSensor`]({{ site.data.project.source_repository_mirror }}/blob/master/samples/utils/src/main/java/org/apache/{{ site.data.project.unix_name }}/samples/utils/sensor/SimpleSimulatedSensor.java). We set the initial gas mileage and delta factor in the first two arguments. The last argument ensures that the sensor reading falls in an acceptable range (between 7.0 mpg and 14.0 mpg). In our `main()`, we use the `poll()` method to generate a flow of tuples (readings), where each tuple arrives every second.
 
 ```java
 // Generate a stream of gas mileage sensor readings

--- a/site/recipes/recipe_external_filter_range.md
+++ b/site/recipes/recipe_external_filter_range.md
@@ -2,7 +2,7 @@
 title: Using an external configuration file for filter ranges
 ---
 
-The [Detecting a sensor value out of range](recipe_value_out_of_range.html) recipe introduced the basics of filtering as well as the use of a [Range]({{ site.docsurl }}/latest/{{ site.data.project.unix_name }}/analytics/sensors/Range.html).
+The [Detecting a sensor value out of range](recipe_value_out_of_range.html) recipe introduced the basics of filtering as well as the use of a [Range]({{ site.docsurl }}/index.html?org/apache/{{ site.data.project.unix_name }}/analytics/sensors/Range.html).
 
 Oftentimes, a user wants to initialize a range specification from an external configuration file so the application code is more easily configured and reusable.
 
@@ -12,7 +12,7 @@ We're going to assume familiarity with that earlier recipe and those concepts an
 
 ## Create a configuration file
 
-The file's syntax is that for a `java.util.Properties` object. See the `Range` [documentation]({{ site.data.project.source_repository_mirror }}/blob/master/analytics/sensors/src/main/java/{{ site.data.project.unix_name }}/analytics/sensors/Range.java) for its string syntax.
+The file's syntax is that for a `java.util.Properties` object. See the `Range` [documentation]({{ site.data.project.source_repository_mirror }}/blob/master/analytics/sensors/src/main/java/org/apache/{{ site.data.project.unix_name }}/analytics/sensors/Range.java) for its string syntax.
 
 Put this into a file:
 

--- a/site/recipes/recipe_value_out_of_range.md
+++ b/site/recipes/recipe_value_out_of_range.md
@@ -46,7 +46,7 @@ public class DetectValueOutOfRange {
 
 ## Generating temperature sensor readings
 
-The next step is to simulate a stream of temperature readings using [`SimulatedTemperatureSensor`]({{ site.data.project.source_repository_mirror }}/blob/master/samples/utils/src/main/java/{{ site.data.project.unix_name }}/samples/utils/sensor/SimulatedTemperatureSensor.java). By default, the sensor sets the initial temperature to 80°F and ensures that new readings are between 28°F and 112°F. In our `main()`, we use the `poll()` method to generate a flow of tuples, where a new tuple (temperature reading) arrives every second.
+The next step is to simulate a stream of temperature readings using [`SimulatedTemperatureSensor`]({{ site.data.project.source_repository_mirror }}/blob/master/samples/utils/src/main/java/org/apache/{{ site.data.project.unix_name }}/samples/utils/sensor/SimulatedTemperatureSensor.java). By default, the sensor sets the initial temperature to 80°F and ensures that new readings are between 28°F and 112°F. In our `main()`, we use the `poll()` method to generate a flow of tuples, where a new tuple (temperature reading) arrives every second.
 
 ```java
 // Generate a stream of temperature sensor readings
@@ -56,7 +56,7 @@ TStream<Double> temp = top.poll(tempSensor, 1, TimeUnit.SECONDS);
 
 ## Simple filtering
 
-If the corn grower is interested in determining when the temperature is strictly out of the optimal range of 77°F and 91°F, a simple filter can be used. The `filter` method can be applied to `TStream` objects, where a filter predicate determines which tuples to keep for further processing. For its method declaration, refer to the [Javadoc]({{ site.docsurl }}/latest/{{ site.data.project.unix_name }}/topology/TStream.html#filter-{{ site.data.project.unix_name }}.function.Predicate-).
+If the corn grower is interested in determining when the temperature is strictly out of the optimal range of 77°F and 91°F, a simple filter can be used. The `filter` method can be applied to `TStream` objects, where a filter predicate determines which tuples to keep for further processing. For its method declaration, refer to the [Javadoc]({{ site.docsurl }}/org/apache/{{ site.data.project.unix_name }}/topology/TStream.html#filter-org.apache.{{ site.data.project.unix_name }}.function.Predicate-).
 
 In this case, we want to keep temperatures below the lower range value *or* above the upper range value. This is expressed in the filter predicate, which follows Java's syntax for [lambda expressions](https://docs.oracle.com/javase/tutorial/java/javaOO/lambdaexpressions.html#syntax). Then, we terminate the stream (using `sink`) by printing out the warning to standard out. Note that `\u00b0` is the Unicode encoding for the degree (°) symbol.
 
@@ -77,7 +77,7 @@ The `deadband` filter is a part of the `edgent.analytics` package focused on han
 deadband(TStream<T> stream, Function<T,V> value, Predicate<V> inBand)
 ```
 
-The first parameter is the stream to the filtered, which is `temp` in our scenario. The second parameter is the value to examine. Here, we use the `identity()` method to return a tuple on the stream. The last parameter is the predicate that defines the optimal range, that is, between 77°F and 91°F. it is important to note that this differs from the `TStream` version of `filter` in which one must explicitly specify the values that are out of range. The code snippet below demonstrates how the method call is pieced together. The `deadbandFiltered` stream contains temperature readings that follow the rules as described in the [Javadoc]({{ site.docsurl }}/latest/{{ site.data.project.unix_name }}/analytics/sensors/Filters.html#deadband-{{ site.data.project.unix_name }}.topology.TStream-{{ site.data.project.unix_name }}.function.Function-{{ site.data.project.unix_name }}.function.Predicate-):
+The first parameter is the stream to the filtered, which is `temp` in our scenario. The second parameter is the value to examine. Here, we use the `identity()` method to return a tuple on the stream. The last parameter is the predicate that defines the optimal range, that is, between 77°F and 91°F. it is important to note that this differs from the `TStream` version of `filter` in which one must explicitly specify the values that are out of range. The code snippet below demonstrates how the method call is pieced together. The `deadbandFiltered` stream contains temperature readings that follow the rules as described in the [Javadoc]({{ site.docsurl }}/org/apache/{{ site.data.project.unix_name }}/analytics/sensors/Filters.html#deadband-org.apache.{{ site.data.project.unix_name }}.topology.TStream-org.apache.{{ site.data.project.unix_name }}.function.Function-org.apache.{{ site.data.project.unix_name }}.function.Predicate-):
 
 * the value is outside of the optimal range (deadband)
 * the first value inside the optimal range after a period being outside it


### PR DESCRIPTION
When working on the rename changes, I forgot to add the `org.apache` package prefix to links.
