### PR TITLE
[EDGENT-323] Create a download page and change links

### DIFF
--- a/site/_config.yml
+++ b/site/_config.yml
@@ -123,6 +123,6 @@ port:    4000
 host:    127.0.0.1
 
 #Base URLs
-sourceurl: https://github.com/apache/incubator-edgent
+sourceurl: http://edgent.incubator.apache.org/docs/downloads.html
 projurl: http://edgent.incubator.apache.org
 docsurl: http://edgent.incubator.apache.org/javadoc/latest

--- a/site/_data/alerts.yml
+++ b/site/_data/alerts.yml
@@ -1,3 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to you under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 tip: '<div class="alert alert-success" role="alert"><i class="fa fa-check-square-o"></i> <b>Tip: </b>'
 note: '<div class="alert alert-info" role="alert"><i class="fa fa-info-circle"></i> <b>Note: </b>'
 important: '<div class="alert alert-warning" role="alert"><i class="fa fa-warning"></i> <b>Important: </b>'

--- a/site/_data/downloads.yml
+++ b/site/_data/downloads.yml
@@ -17,8 +17,12 @@
 # Edgent download location configurations
 #
 
-edgent_lastest_tar_location: 'http://www.apache.org/dyn/closer.lua/incubator/edgent/1.0.0-incubating/binaries/apache-edgent-1.0.0-incubating-bin.tgz'
 
-edgent_1-0-0_src_location: 'http://www.apache.org/dyn/closer.lua/incubator/edgent/1.0.0-incubating/apache-edgent-1.0.0-incubating-src.tgz'
-edgent_1-0-0_tar_location: 'http://www.apache.org/dyn/closer.lua/incubator/edgent/1.0.0-incubating/binaries/apache-edgent-1.0.0-incubating-bin.tgz'
+edgent_1-0-0_src_location: 'http://www.apache.org/dyn/closer.cgi/incubator/edgent/1.0.0-incubating'
 edgent_1-0-0_doc_location: 'http://edgent.incubator.apache.org/javadoc/r1.0.0/index.html'
+edgent_1-0-0_release_note: 'https://github.com/apache/incubator-edgent/blob/1.0.0-incubating/RELEASE_NOTES'
+edgent_dist_main_location: 'http://www.apache.org/dyn/closer.cgi/incubator/edgent'
+edgent_keys_file_location: 'https://www.apache.org/dist/incubator/edgent/KEYS'
+edgent_1-0-0_asc_location: 'https://www.apache.org/dist/incubator/edgent/1.0.0-incubating/apache-edgent-1.0.0-incubating-src.tgz.asc'
+edgent_1-0-0_md5_location: 'https://www.apache.org/dist/incubator/edgent/1.0.0-incubating/apache-edgent-1.0.0-incubating-src.tgz.md5'
+edgent_1-0-0_sha_location: 'https://www.apache.org/dist/incubator/edgent/1.0.0-incubating/apache-edgent-1.0.0-incubating-src.tgz.sha'

--- a/site/_data/downloads.yml
+++ b/site/_data/downloads.yml
@@ -1,0 +1,24 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to you under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# Edgent download location configurations
+#
+
+edgent_lastest_tar_location: 'http://www.apache.org/dyn/closer.lua/incubator/edgent/1.0.0-incubating/binaries/apache-edgent-1.0.0-incubating-bin.tgz'
+
+edgent_1-0-0_src_location: 'http://www.apache.org/dyn/closer.lua/incubator/edgent/1.0.0-incubating/apache-edgent-1.0.0-incubating-src.tgz'
+edgent_1-0-0_tar_location: 'http://www.apache.org/dyn/closer.lua/incubator/edgent/1.0.0-incubating/binaries/apache-edgent-1.0.0-incubating-bin.tgz'
+edgent_1-0-0_doc_location: 'http://edgent.incubator.apache.org/javadoc/r1.0.0/index.html'

--- a/site/_data/mydoc/mydoc_definitions.yml
+++ b/site/_data/mydoc/mydoc_definitions.yml
@@ -1,3 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to you under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 elephant: "This is a sample definition."
 
 baseball: "Baseball is considered America's pasttime sport, though that may be more of a historical term than a current one. There's a lot more excitement about football than baseball. A baseball game is somewhat of a snooze to watch, for the most part."

--- a/site/_data/mydoc/mydoc_glossary.yml
+++ b/site/_data/mydoc/mydoc_glossary.yml
@@ -1,3 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to you under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 jekyll_platform: "Jekyll is a static site generator that builds sites using most modern web technologies."
 
 fractious: "Like a little mischevious child, full of annoying and constant trouble."

--- a/site/_data/mydoc/mydoc_sidebar.yml
+++ b/site/_data/mydoc/mydoc_sidebar.yml
@@ -1,3 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to you under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # This is your sidebar TOC. The sidebar code loops through sections here and provides the appropriate formatting.
 
 # Sidebar
@@ -58,6 +73,14 @@ entries:
     version: all
     output: web, pdf
     items:
+    - title: Downloads
+      url: /docs/downloads.html
+      audience: writers, designers
+      platform: all
+      product: all
+      version: all
+      output: web, pdf
+
     - title: Getting started guide
       url: /docs/edgent-getting-started.html
       audience: writers, designers

--- a/site/_data/mydoc/mydoc_tags.yml
+++ b/site/_data/mydoc/mydoc_tags.yml
@@ -1,3 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to you under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 allowed-tags:
   - getting_started
   - content_types

--- a/site/_data/mydoc/mydoc_topnav.yml
+++ b/site/_data/mydoc/mydoc_topnav.yml
@@ -1,3 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to you under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 ## Topnav single links
 ## if you want to list an external url, use external_url instead of url. the theme will apply a different link base.
 #    - title: Sample

--- a/site/_data/mydoc/mydoc_urls.yml
+++ b/site/_data/mydoc/mydoc_urls.yml
@@ -1,22 +1,17 @@
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to you under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 home:
   title: "Introduction"

--- a/site/_data/mydoc/samplelist.yml
+++ b/site/_data/mydoc/samplelist.yml
@@ -1,3 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to you under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 entries:
 - title: Sidebar
   subcategories:

--- a/site/_data/project.yml
+++ b/site/_data/project.yml
@@ -23,7 +23,7 @@ incubator_name: incubator-edgent
 incubator_slash_name: incubator/edgent
 description: Edgent is a community for accelerating analytics in edge devices. 
 
-download: https://github.com/apache/incubator-edgent
+download: http://edgent.incubator.apache.org/docs/downloads
 
 dev_list: dev@edgent.incubator.apache.org
 dev_list_subscribe: dev-subscribe@edgent.incubator.apache.org

--- a/site/_data/project.yml
+++ b/site/_data/project.yml
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 #
 # Edgent Project configurations
 #

--- a/site/_data/project.yml
+++ b/site/_data/project.yml
@@ -23,7 +23,7 @@ incubator_name: incubator-edgent
 incubator_slash_name: incubator/edgent
 description: Edgent is a community for accelerating analytics in edge devices. 
 
-download: http://edgent.incubator.apache.org/docs/downloads
+download: downloads
 
 dev_list: dev@edgent.incubator.apache.org
 dev_list_subscribe: dev-subscribe@edgent.incubator.apache.org

--- a/site/_data/strings.yml
+++ b/site/_data/strings.yml
@@ -1,4 +1,17 @@
-
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to you under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # placed here for translation purposes
 search_placeholder_text: search...

--- a/site/_data/terms.yml
+++ b/site/_data/terms.yml
@@ -1,1 +1,15 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to you under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 apple: "apple - the fruit of a disiduous tree."

--- a/site/docs/downloads.md
+++ b/site/docs/downloads.md
@@ -1,0 +1,13 @@
+---
+title: Downloads
+---
+
+## Download now.
+
+To download lastest binaries version of Apache Edgent (incubating), click [here]({{ site.data.downloads.edgent_lastest_tar_location }}).
+
+## Apache Edgent (incubating) release history
+
+| Version           | Date           | Source | Binaries | Docs |
+| ------------------|:--------------:| -----:|-----:|-----:|
+| 1.0.0-incubating  | 2016-12-13     | [edgent-1.0.0-src.tgz]({{ site.data.downloads.edgent_1-0-0_src_location }}) | [edgent-1.0.0-bin.tgz]({{ site.data.downloads.edgent_1-0-0_tar_location }})  |[1.0.0 JavaDoc]({{ site.data.downloads.edgent_1-0-0_doc_location }}) |

--- a/site/docs/downloads.md
+++ b/site/docs/downloads.md
@@ -4,10 +4,22 @@ title: Downloads
 
 ## Download now.
 
-To download lastest binaries version of Apache Edgent (incubating), click [here]({{ site.data.downloads.edgent_lastest_tar_location }}).
+Official Apache Edgent releases are available for download from the ASF distribution site. A release consists of a source code bundle and a convenience binary bundle. The Edgent ASF distribution site is [here]({{ site.data.downloads.edgent_dist_main_location }}). Information about verifying the integrity of the release bundles can also be found there.
+
+The Edgent source is also available from the Edgent ASF [git repository]({{ site.data.project.source_repository }}).
+
+If you just want to use Edgent, it is easiest to download and unpack a binary bundle. The bundle includes the release's javadoc. The javadoc is also accessible online. For more information, please refer to the [Getting started guide](edgent-getting-started)
+
+A source bundle contains a README describing how to build the sources.
+
+If you want access the latest unreleased Edgent source or to contribute to Edgent runtime development, using the [GitHub]({{  site.data.project.source_repository_mirror }}) repository is recommended. You can also select a particular release version by release tag (e.g., 1.0.0-incubating). See README.md and DEVELOPMENT.md in the repository for more information.
+
+See [here](community.html) for more information about contributing to Edgent development.
 
 ## Apache Edgent (incubating) release history
 
-| Version           | Date           | Source | Binaries | Docs |
-| ------------------|:--------------:| -----:|-----:|-----:|
-| 1.0.0-incubating  | 2016-12-13     | [edgent-1.0.0-src.tgz]({{ site.data.downloads.edgent_1-0-0_src_location }}) | [edgent-1.0.0-bin.tgz]({{ site.data.downloads.edgent_1-0-0_tar_location }})  |[1.0.0 JavaDoc]({{ site.data.downloads.edgent_1-0-0_doc_location }}) |
+| Version           | Date           | Source | Release Notes | Docs | GPG | MD5 | SHA   |
+|:-----------------:|:--------------:|:------:|:-------------:|:----:|:---:|:---:|:-----:|
+| 1.0.0-incubating  | 2016-12-15     | [Download]({{ site.data.downloads.edgent_1-0-0_src_location }}) | [1.0.0 Release]({{ site.data.downloads.edgent_1-0-0_release_note }}) | [JavaDoc]({{ site.data.downloads.edgent_1-0-0_doc_location }}) | [ASC]({{ site.data.downloads.edgent_1-0-0_asc_location  }}) | [MD5]({{  site.data.downloads.edgent_1-0-0_md5_location }}) | [SHA]({{  site.data.downloads.edgent_1-0-0_sha_location }}) |
+
+Download the [KEYS file]({{ site.data.downloads.edgent_keys_file_location }}) to verify the Edgent artifact

--- a/site/docs/edgent-getting-started.md
+++ b/site/docs/edgent-getting-started.md
@@ -25,9 +25,9 @@ Edgent's primary API is functional where streams are sourced, transformed, analy
 
 ### Downloading Apache Edgent
 
-To download Edgent, please refer to [here]({{ site.data.project.download }}). And you can read more about building Edgent [here]({{ site.data.project.source_repository_mirror }}/blob/master/DEVELOPMENT.md).
+To use Edgent you need the Edgent jars. You can either download the Edgent source and build it or you can download a pre-built version of Edgent. See the [download page]({{ site.data.project.download }}).
 
-After you build the Edgent package, you can set up your environment.
+After you have the Edgent jars, you can set up your environment.
 
 ### Setting up your environment
 

--- a/site/docs/edgent-getting-started.md
+++ b/site/docs/edgent-getting-started.md
@@ -25,7 +25,7 @@ Edgent's primary API is functional where streams are sourced, transformed, analy
 
 ### Downloading Apache Edgent
 
-To use Edgent, access the source code and build it. You can read more about building Edgent [here]({{ site.data.project.source_repository_mirror }}/blob/master/DEVELOPMENT.md).
+To download Edgent, please refer to [here]({{ site.data.project.download }}). And you can read more about building Edgent [here]({{ site.data.project.source_repository_mirror }}/blob/master/DEVELOPMENT.md).
 
 After you build the Edgent package, you can set up your environment.
 

--- a/site/docs/faq.md
+++ b/site/docs/faq.md
@@ -44,7 +44,7 @@ Edgent is a tool for edge analytics that allows you to be more productive. Edgen
 
 ## Where can I download Apache Edgent to try it out?
 
-You can download the source from Apache and build it yourself [here]({{ site.data.project.download }}). You can also find already pre-built Apache releases of Edgent for download [here]({{ site.data.project.apache_release_location }}) (But this location is temporarily unavailable until we get the first release out).
+You can download Apache Edgent from [here]({{ site.data.project.download }}).
 
 ## How do I get started?
 

--- a/site/docs/faq.md
+++ b/site/docs/faq.md
@@ -44,7 +44,7 @@ Edgent is a tool for edge analytics that allows you to be more productive. Edgen
 
 ## Where can I download Apache Edgent to try it out?
 
-You can download the source from Apache and build it yourself [here]({{ site.data.project.source_repository_mirror }}). You can also find already pre-built Apache releases of Edgent for download [here]({{ site.data.project.apache_release_location }}) (But this location is temporarily unavailable until we get the first release out).
+You can download the source from Apache and build it yourself [here]({{ site.data.project.download }}). You can also find already pre-built Apache releases of Edgent for download [here]({{ site.data.project.apache_release_location }}) (But this location is temporarily unavailable until we get the first release out).
 
 ## How do I get started?
 


### PR DESCRIPTION
- Created a download page(docs/downloads.html) It includes [src](http://www.apache.org/dyn/closer.lua/incubator/edgent/1.0.0-incubating/apache-edgent-1.0.0-incubating-src.tgz), [bin](http://www.apache.org/dyn/closer.lua/incubator/edgent/1.0.0-incubating/binaries/apache-edgent-1.0.0-incubating-bin.tgz) location
- Changed most of download links from github to newly created download page
- Download links cannot be direct linked in your local environment now (most of configuration use edgent domain instead of localhost address. It will be resolved after deployed to production. If you wanna to test download pages, please type http://localhost:4040/docs/downloads.html or go to docs-> Get Started -> Downloads)

I'm very newbie on website.. So please do not hesitate to advice me :) It will be great help to me