### PR TITLE
[Edgent-326] website faqs, downloads cleanup

### DIFF
--- a/site/_config.yml
+++ b/site/_config.yml
@@ -123,6 +123,7 @@ port:    4000
 host:    127.0.0.1
 
 #Base URLs
+sourcerepourl: https://github.com/apache/incubator-edgent
 downloadsurl: /docs/downloads
 projurl: /
 #docsurl: /javadoc/latest

--- a/site/_config.yml
+++ b/site/_config.yml
@@ -37,7 +37,7 @@ disqus_shortname: idrbwjekyll
 # variables
 
 sidebar_tagline: Edgent
-sidebar_version: Version 1.0.0
+sidebar_version: Version 1.0.0-incubating
 theme_file: theme-blue.css
 
 # the algolia entries here are experimental only.
@@ -92,7 +92,7 @@ defaults:
 url: http://edgent.incubator.apache.org
 baseurl:
 title: Apache Edgent
-description: Edgent is an open source community for accelerating analytics at the edge.
+description: Apache Edgent is an open source community for accelerating analytics at the edge.
 
 # ----------------------- #
 #    Jekyll & Plugins     #
@@ -114,15 +114,20 @@ social:
   - title: twitter
     url: https://twitter.com/ApacheEdgent
   - title: github
-    url: https://github.com/quarks-edge/quarks/
+    url: https://github.com/apache/incubator-edgent
   - title: stack-overflow
-    url: http://stackoverflow.com/questions/ask?tags=edgent
+    url: http://stackoverflow.com/questions/ask?tags=apache-edgent
 
 detach:  false
 port:    4000
 host:    127.0.0.1
 
 #Base URLs
-sourceurl: http://edgent.incubator.apache.org/docs/downloads.html
-projurl: http://edgent.incubator.apache.org
-docsurl: http://edgent.incubator.apache.org/javadoc/latest
+downloadsurl: /docs/downloads
+projurl: /
+#docsurl: /javadoc/latest
+# above yields things like the following when running on a "jekyll serve" test server
+# [2016-12-22 15:23:31] ERROR `/favicon.ico' not found.
+# [2016-12-22 15:33:17] ERROR `/javadoc/latest/resources/fonts/dejavu.css' not found.
+# the following is undesirable as it doesn't link to the "jekyll serve" test server
+docsurl: https://edgent.incubator.apache.org/javadoc/latest

--- a/site/_data/downloads.yml
+++ b/site/_data/downloads.yml
@@ -18,11 +18,16 @@
 #
 
 
-edgent_1-0-0_src_location: 'http://www.apache.org/dyn/closer.cgi/incubator/edgent/1.0.0-incubating'
-edgent_1-0-0_doc_location: 'http://edgent.incubator.apache.org/javadoc/r1.0.0/index.html'
-edgent_1-0-0_release_note: 'https://github.com/apache/incubator-edgent/blob/1.0.0-incubating/RELEASE_NOTES'
-edgent_dist_main_location: 'http://www.apache.org/dyn/closer.cgi/incubator/edgent'
+edgent_dist_main_location: 'https://www.apache.org/dyn/closer.cgi/incubator/edgent'
 edgent_keys_file_location: 'https://www.apache.org/dist/incubator/edgent/KEYS'
+
+edgent_1-0-0_release_note: 'https://github.com/apache/incubator-edgent/blob/1.0.0-incubating/RELEASE_NOTES'
+edgent_1-0-0_doc_location: 'https://edgent.incubator.apache.org/javadoc/r1.0.0/index.html'
+edgent_1-0-0_dist_location: 'https://www.apache.org/dyn/closer.cgi/incubator/edgent/1.0.0-incubating'
 edgent_1-0-0_asc_location: 'https://www.apache.org/dist/incubator/edgent/1.0.0-incubating/apache-edgent-1.0.0-incubating-src.tgz.asc'
 edgent_1-0-0_md5_location: 'https://www.apache.org/dist/incubator/edgent/1.0.0-incubating/apache-edgent-1.0.0-incubating-src.tgz.md5'
 edgent_1-0-0_sha_location: 'https://www.apache.org/dist/incubator/edgent/1.0.0-incubating/apache-edgent-1.0.0-incubating-src.tgz.sha'
+edgent_1-0-0_bin_dist_location: 'https://www.apache.org/dyn/closer.cgi/incubator/edgent/1.0.0-incubating/binaries'
+edgent_1-0-0_bin_asc_location: 'https://www.apache.org/dist/incubator/edgent/1.0.0-incubating/binaries/apache-edgent-1.0.0-incubating-bin.tgz.asc'
+edgent_1-0-0_bin_md5_location: 'https://www.apache.org/dist/incubator/edgent/1.0.0-incubating/binaries/apache-edgent-1.0.0-incubating-bin.tgz.md5'
+edgent_1-0-0_bin_sha_location: 'https://www.apache.org/dist/incubator/edgent/1.0.0-incubating/binaries/apache-edgent-1.0.0-incubating-bin.tgz.sha'

--- a/site/_data/mydoc/mydoc_topnav.yml
+++ b/site/_data/mydoc/mydoc_topnav.yml
@@ -118,3 +118,11 @@ topnav_dropdowns:
           product: all
           version: all
           output: web
+
+        - title: edgent.apache.org
+          external_url: https://edgent.incubator.apache.org/
+          audience: writers, designers
+          platform: all
+          product: all
+          version: all
+          output: web

--- a/site/_data/mydoc/mydoc_topnav.yml
+++ b/site/_data/mydoc/mydoc_topnav.yml
@@ -120,7 +120,7 @@ topnav_dropdowns:
           output: web
 
         - title: edgent.apache.org
-          external_url: https://edgent.incubator.apache.org/
+          url: /
           audience: writers, designers
           platform: all
           product: all

--- a/site/_data/project.yml
+++ b/site/_data/project.yml
@@ -21,7 +21,7 @@ short_name: Edgent
 unix_name: edgent
 incubator_name: incubator-edgent
 incubator_slash_name: incubator/edgent
-description: Edgent is a community for accelerating analytics in edge devices. 
+description: Apache Edgent is a community for accelerating analytics in edge devices. 
 
 download: downloads
 

--- a/site/_includes/header.html
+++ b/site/_includes/header.html
@@ -62,7 +62,7 @@ limitations under the License.
                     <span class="icon-bar"></span>
                     <span class="icon-bar"></span>
                 </button>
-                <a class="navbar-brand page-scroll" href="http://{{ site.data.project.unix_name }}.incubator.apache.org/#home">Home</a>
+                <a class="navbar-brand page-scroll" href="/#home">Home</a>
             </div>
             <!-- Collect the nav links, forms, and other content for toggling -->
             <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">

--- a/site/_includes/header.html
+++ b/site/_includes/header.html
@@ -85,7 +85,7 @@ limitations under the License.
                     <li class="dropdown"><a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Getting Started</a>
                       <ul class="dropdown-menu">
                         <li><a href="docs/edgent-getting-started">Getting Started Guide</a></li>
-                        <li><a href="docs/downloads">Download Source</a></li>
+                        <li><a href="docs/downloads">Downloads</a></li>
                         <li><a href="docs/samples">Sample Programs</a></li>
                         <li><a href="docs/faq">FAQ</a></li>
 
@@ -110,7 +110,7 @@ limitations under the License.
                 </ul>
                 <ul class="nav navbar-nav navbar-right">
                     <li>
-                        <a href="{{ site.sourceurl }}">Download Source</a>
+                        <a href="{{ site.downloadsurl }}">Downloads</a>
                     </li>
                    <!-- <li>
                         <a class="page-scroll" href="#services">Services</a>

--- a/site/_includes/header.html
+++ b/site/_includes/header.html
@@ -70,7 +70,7 @@ limitations under the License.
                     <li class="dropdown"><a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">About Edgent</a>
                       <ul class="dropdown-menu">
                         <li><a href="/docs/overview">About Edgent</a></li>
-                        <li><a href="{{ site.sourceurl }}/blob/master/LICENSE">License</a></li>
+                        <li><a href="{{ site.sourcerepourl }}/blob/master/LICENSE">License</a></li>
                       </ul>
                     </li>
                     <li class="dropdown"><a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Community</a>

--- a/site/doap_Edgent.rdf
+++ b/site/doap_Edgent.rdf
@@ -27,7 +27,7 @@
     <name>Apache Edgent</name>
     <homepage rdf:resource="http://edgent.incubator.apache.org/" />
     <asfext:pmc rdf:resource="http://incubator.apache.org" />
-    <shortdesc>Edgent is a stream processing programming model and lightweight runtime to execute analytics at devices on the edge or at the gateway.</shortdesc>
+    <shortdesc>Apache Edgent is a stream processing programming model and lightweight micro-kernel style runtime to execute analytics at devices on the edge or at the gateway.</shortdesc>
     <description>Apache Edgent is a programming model and micro-kernel style runtime that can be embedded in gateways and small footprint edge devices enabling local, real-time, analytics on the continuous streams of data coming from equipment, vehicles, systems, appliances, devices and sensors of all kinds (for example, Raspberry Pis or smart phones). Working in conjunction with centralized analytic systems, Apache Edgent provides efficient and timely analytics across the whole IoT ecosystem: from the center to the edge.</description>
     <bug-database rdf:resource="https://issues.apache.org/jira/browse/EDGENT" />
     <mailing-list rdf:resource="http://edgent.incubator.apache.org/docs/community#mailing-list" />

--- a/site/docs/downloads.md
+++ b/site/docs/downloads.md
@@ -2,22 +2,24 @@
 title: Downloads
 ---
 
-Official Apache Edgent releases are available for download from the ASF distribution site. A release consists of a source code bundle and a convenience binary bundle. The Edgent ASF distribution site is [here]({{ site.data.downloads.edgent_dist_main_location }}). Information about verifying the integrity of the release bundles can also be found there.
-
-The Edgent source is also available from the Edgent ASF [git repository]({{ site.data.project.source_repository }}).
+Official Apache Edgent releases are available for download from the ASF distribution site. A release consists of a source code bundle and a convenience binary bundle. See the table below for a release's download links.
 
 If you just want to use Edgent, it is easiest to download and unpack a binary bundle. The bundle includes the release's javadoc. The javadoc is also accessible online. For more information, please refer to the [Getting started guide](edgent-getting-started)
 
 A source bundle contains a README describing how to build the sources.
 
-If you want access the latest unreleased Edgent source or to contribute to Edgent runtime development, using the [GitHub repository]({{  site.data.project.source_repository_mirror }}) is recommended. You can also select a particular release version by release tag (e.g., 1.0.0-incubating). See README.md and DEVELOPMENT.md in the repository for more information.
+If you want to access the latest unreleased Edgent source or to contribute to the Edgent runtime development, use the [GitHub repository]({{  site.data.project.source_repository_mirror }}). You can also select a particular release version by release tag (e.g., 1.0.0-incubating). See README.md and DEVELOPMENT.md in the repository for more information.
 
-See [here](community.html) for more information about contributing to Edgent development.
+See [community](community.html) for more information about contributing to Edgent development.
 
-## Apache Edgent (incubating) release history
+## Apache Edgent Releases
 
-| Version           | Date           | Source | Release Notes | Docs | GPG | MD5 | SHA   |
-|:-----------------:|:--------------:|:------:|:-------------:|:----:|:---:|:---:|:-----:|
-| 1.0.0-incubating  | 2016-12-15     | [Download]({{ site.data.downloads.edgent_1-0-0_src_location }}) | [1.0.0 Release]({{ site.data.downloads.edgent_1-0-0_release_note }}) | [JavaDoc]({{ site.data.downloads.edgent_1-0-0_doc_location }}) | [ASC]({{ site.data.downloads.edgent_1-0-0_asc_location  }}) | [MD5]({{  site.data.downloads.edgent_1-0-0_md5_location }}) | [SHA]({{  site.data.downloads.edgent_1-0-0_sha_location }}) |
+Information about verifying the integrity of a bundle can be found at the bottom of the bundle's download page.
 
-Download the [KEYS file]({{ site.data.downloads.edgent_keys_file_location }}) to verify the Edgent artifact
+Download the [KEYS]({{ site.data.downloads.edgent_keys_file_location }}) file for verifying a bundle's PGP signature.
+
+
+| Version           | Date           | Bundles | Release Notes | Docs | PGP | MD5 | SHA   |
+|:-----------------:|:--------------:|:-------:|:-------------:|:----:|:---:|:---:|:-----:|
+| 1.0.0-incubating  | 2016-12-15     | [Source]({{ site.data.downloads.edgent_1-0-0_dist_location }}) | [1.0.0 Release]({{ site.data.downloads.edgent_1-0-0_release_note }}) | [JavaDoc]({{ site.data.downloads.edgent_1-0-0_doc_location }}) | [ASC]({{ site.data.downloads.edgent_1-0-0_asc_location  }}) | [MD5]({{  site.data.downloads.edgent_1-0-0_md5_location }}) | [SHA]({{  site.data.downloads.edgent_1-0-0_sha_location }}) |
+|                   |                | [Binary]({{ site.data.downloads.edgent_1-0-0_bin_dist_location }}) | | | [ASC]({{ site.data.downloads.edgent_1-0-0_bin_asc_location  }}) | [MD5]({{  site.data.downloads.edgent_1-0-0_bin_md5_location }}) | [SHA]({{  site.data.downloads.edgent_1-0-0_bin_sha_location }}) |

--- a/site/docs/faq.md
+++ b/site/docs/faq.md
@@ -42,9 +42,9 @@ Edgent is designed for the edge, rather than a more centralized system. It has a
 
 Edgent is a tool for edge analytics that allows you to be more productive. Edgent provides a consistent data model (streams and windows) and provides useful functionality, such as aggregations, joins, etc. Using Edgent lets you to take advantage of this functionality, allowing you to focus on your application needs.
 
-## Where can I download Apache Edgent to try it out?
+## Where can I download Apache Edgent?
 
-You can download Apache Edgent from [here]({{ site.data.project.download }}).
+Releases include source code and convenience binary bundles.  The source code is also available on GitHub.  The [downloads]({{ site.data.project.download }}) page has all of the details.
 
 ## How do I get started?
 
@@ -61,10 +61,6 @@ Just submit a [pull request]({{ site.data.project.source_repository_mirror }}/pu
 ## Can I become a committer?
 
 Read about Edgent committers and how to become a committer [here](committers).
-
-## Where can I get the code?
-
-The source code is available [here]({{ site.data.project.source_repository_mirror }}).
 
 ## Can I take a copy of the code and fork it for my own use?
 
@@ -88,4 +84,4 @@ With the growth of the Internet of Things there is a need to execute analytics a
 
 ## I see references to "Quarks." How does it relate to Apache Edgent?
 
-Up until July 2016, Edgent was known as Quarks. Quarks was renamed due to the name not being unique enough. The suitable name search for Edgent is currently in progress at The Apache Software Foundation.
+Up until July 2016, Edgent was known as Quarks. Quarks was renamed due to the name not being unique enough.

--- a/site/recipes/recipe_source_function.md
+++ b/site/recipes/recipe_source_function.md
@@ -51,6 +51,8 @@ public static void main(String[] args) throws Exception {
     final URL url = new URL("http://finance.yahoo.com/d/quotes.csv?s=BAC+COG+FCX&f=snabl");
 
     TStream<String> linesOfWebsite = top.source(queryWebsite(url));
+
+    dp.submit(top);
 }
 ```
 


### PR DESCRIPTION
- clarify 1.0.0-incubating on sidebar of doc
- change quarks github reference to edgent
- fix stackoverflow apache-edgent tag reference
- define separate src and bin download urls for signatures, ...
- add way to navigate back to edgent home from documentation page (Edgent References -> ...)
- change Download Source to Downloads
- refactor the downloads page to simplify and for separate src vs bin signatures, etc
- tweak doap_Edgent.rdf
- simplify and correct stuff in faq
- fix source-function recipe (EDGENT-322)
- fix About Edgent -> License
- fix Home button to stay within site - e.g., when running under test under jekyll serve